### PR TITLE
Fix the frozen status of the key account creation button

### DIFF
--- a/app/src/main/java/org/nem/nac/ui/activities/CreateAccountActivity.java
+++ b/app/src/main/java/org/nem/nac/ui/activities/CreateAccountActivity.java
@@ -3,6 +3,8 @@ package org.nem.nac.ui.activities;
 import android.content.Intent;
 import android.graphics.Color;
 import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextWatcher;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
@@ -55,7 +57,9 @@ public final class CreateAccountActivity extends NacBaseActivity {
 		setTitle(_importPrivKey ? R.string.title_activity_import_key : R.string.title_activity_create_account);
 
 		_inputAccName = (EditText)findViewById(R.id.input_account_name);
+		_inputAccName.addTextChangedListener(textWatcher);
 		_inputPrivateKey = ((PrivateKeyInput)findViewById(R.id.input_private_key));
+		_inputPrivateKey.addTextChangedListener(textWatcher);
 		_createAccountConfirm = (Button)findViewById(R.id.btn_create_account_confirm);
 		_createAccountConfirm.setOnClickListener(this::onConfirmAccount);
 		if (_importPrivKey) {
@@ -101,4 +105,23 @@ public final class CreateAccountActivity extends NacBaseActivity {
 		AddressInfoProvider.instance().invalidateLocal();
 		AccountListActivity.start(this);
 	}
+
+		public TextWatcher textWatcher = new TextWatcher() {
+		@Override
+		public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+
+		}
+
+		@Override
+		public void onTextChanged(CharSequence s, int start, int before, int count) {
+
+		}
+
+		@Override
+		public void afterTextChanged(Editable s) {
+			//Resetting the button state when the user change the text, otherwise the button remain unclickable
+			_createAccountConfirm.setClickable(true);
+		}
+	};
+
 }


### PR DESCRIPTION
NBODCP-XW5R7X-FZ4R3I-ZNEIM2-Y7S3TE-VKJ42J-KQZ7

**The bug description:**
Once the user enter a wrong private key or click the "Create" button while keeping one of the InputText empty, the button became not-clickable.
Then, even if the user correct or enter correct data, the button remain not-clickable.
Thus, the application hangs in this state until the user close the activity, even with the correct data, which will confuse the user with his top secret private key.

**Reproduce the bug:**
1° Click the "Create" button while inserting an inacceptable private key or leaving one or the two InputText empty.
![sh01](https://user-images.githubusercontent.com/2495140/31705230-d3fc2114-b3e4-11e7-9b81-775b90c2d616.png)

2° The "Create" button became not-clickable
3° Enter a correct private key and a correct name, but the button is always in not-clickable state.
![sh02](https://user-images.githubusercontent.com/2495140/31705242-e26092bc-b3e4-11e7-8669-576c9f347135.png)

**The solution:**
The solution is to attach a TextWatcher to the two InputTexts and reset the state of the "Create" button everytime the user update the entered data, then process the verification after each click.