### PR TITLE
Actually finish the Login Activity 

### DIFF
--- a/app/src/main/java/org/nem/nac/ui/activities/LoginActivity.java
+++ b/app/src/main/java/org/nem/nac/ui/activities/LoginActivity.java
@@ -84,6 +84,7 @@ public final class LoginActivity extends NacBaseActivity {
 			intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
 			intent.putExtra(EXTRA_BOOL_EXIT_ATTEMPT, true);
 			startActivity(intent);
+			finish();
 		}
 	}
 


### PR DESCRIPTION
on API 15 devices after Back button pressed the activity didn't call finish(), so it wasn't finishing, which was the expected behavior.

In order to test this, you will need to either make false the Android version comparation by replacing it, or just switching it into < 16, whatever it is preferred when testing it (if device version is API 16+, of course).