### PR TITLE
Update project files so it builds in Android Studio 3+

### DIFF
--- a/app/app.iml
+++ b/app/app.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":app" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" external.system.module.group="NemAndroidClient" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":app" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="android-gradle" name="Android-Gradle">
       <configuration>
@@ -8,11 +8,11 @@
     </facet>
     <facet type="android" name="Android">
       <configuration>
-        <option name="SELECTED_BUILD_VARIANT" value="_testnetDebug" />
-        <option name="ASSEMBLE_TASK_NAME" value="assemble_testnetDebug" />
-        <option name="COMPILE_JAVA_TASK_NAME" value="compile_testnetDebugSources" />
+        <option name="SELECTED_BUILD_VARIANT" value="_mainnetDebug" />
+        <option name="ASSEMBLE_TASK_NAME" value="assemble_mainnetDebug" />
+        <option name="COMPILE_JAVA_TASK_NAME" value="compile_mainnetDebugSources" />
         <afterSyncTasks>
-          <task>generate_testnetDebugSources</task>
+          <task>generate_mainnetDebugSources</task>
         </afterSyncTasks>
         <option name="ALLOW_USER_CONFIGURATION" value="false" />
         <option name="MANIFEST_FILE_RELATIVE_PATH" value="/src/main/AndroidManifest.xml" />
@@ -22,60 +22,68 @@
       </configuration>
     </facet>
   </component>
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8" inherit-compiler-output="false">
-    <output url="file://$MODULE_DIR$/build/retrolambda/_testnetDebug" />
-    <output-test url="file://$MODULE_DIR$/build/intermediates/classes/test/_testnet/debug" />
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
+    <output url="file://$MODULE_DIR$/build/intermediates/classes/_mainnet/debug" />
+    <output-test url="file://$MODULE_DIR$/build/intermediates/classes/test/_mainnet/debug" />
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/_testnet/debug" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/_testnet/debug" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/_testnet/debug" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/_testnet/debug" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/apt/_testnet/debug" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/_testnet/debug" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/_testnet/debug" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/_testnetDebug/res" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/_testnetDebug/resources" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/_testnetDebug/assets" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/_testnetDebug/aidl" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/_testnetDebug/java" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/_testnetDebug/rs" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/_testnetDebug/shaders" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test_testnetDebug/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test_testnetDebug/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test_testnetDebug/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test_testnetDebug/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test_testnetDebug/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test_testnetDebug/rs" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test_testnetDebug/shaders" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/androidTest/_testnet/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/androidTest/_testnet/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/androidTest/_testnet/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/androidTest/_testnet/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/apt/androidTest/_testnet/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/androidTest/_testnet/debug" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/androidTest/_testnet/debug" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/_testnet/res" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/_testnet/resources" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/_testnet/assets" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/_testnet/aidl" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/_testnet/java" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/_testnet/rs" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/_testnet/shaders" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test_testnet/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test_testnet/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test_testnet/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test_testnet/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test_testnet/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test_testnet/rs" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test_testnet/shaders" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest_testnet/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest_testnet/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest_testnet/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest_testnet/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest_testnet/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest_testnet/rs" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest_testnet/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/apt/_mainnet/debug" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/_mainnet/debug" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/_mainnet/debug" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/_mainnet/debug" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/_mainnet/debug" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/_mainnet/debug" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/_mainnet/debug" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/_mainnetDebug/res" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/_mainnetDebug/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/_mainnetDebug/assets" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/_mainnetDebug/aidl" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/_mainnetDebug/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/_mainnetDebug/rs" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/_mainnetDebug/shaders" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/apt/androidTest/_mainnet/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/androidTest/_mainnet/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/androidTest/_mainnet/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/androidTest/_mainnet/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/androidTest/_mainnet/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/androidTest/_mainnet/debug" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/androidTest/_mainnet/debug" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest_mainnetDebug/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest_mainnetDebug/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest_mainnetDebug/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest_mainnetDebug/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest_mainnetDebug/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest_mainnetDebug/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest_mainnetDebug/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/apt/test/_mainnet/debug" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test_mainnetDebug/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test_mainnetDebug/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test_mainnetDebug/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test_mainnetDebug/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test_mainnetDebug/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test_mainnetDebug/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test_mainnetDebug/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/_mainnet/res" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/_mainnet/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/_mainnet/assets" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/_mainnet/aidl" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/_mainnet/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/_mainnet/rs" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/_mainnet/shaders" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest_mainnet/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest_mainnet/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest_mainnet/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest_mainnet/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest_mainnet/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest_mainnet/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest_mainnet/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test_mainnet/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test_mainnet/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test_mainnet/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test_mainnet/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test_mainnet/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test_mainnet/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test_mainnet/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/assets" type="java-resource" />
@@ -90,6 +98,13 @@
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/assets" type="java-resource" />
@@ -97,13 +112,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/shaders" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
@@ -111,55 +119,72 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/check-manifest" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-safeguard" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/javaPrecompile" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jniLibs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/multi-dex" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/prebuild" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/processing-tools" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/shaders" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/splits-support" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/transforms" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
-      <excludeFolder url="file://$MODULE_DIR$/build/retrolambda" />
+      <excludeFolder url="file://$MODULE_DIR$/build/reports" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
-    <orderEntry type="jdk" jdkName="Android API 25 Platform (4)" jdkType="Android SDK" />
+    <orderEntry type="jdk" jdkName="Android API 27 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" exported="" name="okhttp-2.3.0" level="project" />
-    <orderEntry type="library" exported="" name="prov-1.51.0.0" level="project" />
-    <orderEntry type="library" exported="" name="transition-25.3.1" level="project" />
-    <orderEntry type="library" exported="" name="acra-4.9.0" level="project" />
-    <orderEntry type="library" exported="" name="design-25.3.1" level="project" />
-    <orderEntry type="library" exported="" name="core-3.2.1" level="project" />
-    <orderEntry type="library" exported="" name="support-core-ui-25.3.1" level="project" />
-    <orderEntry type="library" exported="" name="cupboard-2.1.4" level="project" />
-    <orderEntry type="library" exported="" name="jackson-annotations-2.6.0" level="project" />
-    <orderEntry type="library" exported="" name="core-1.51.0.0" level="project" />
-    <orderEntry type="library" exported="" name="support-core-utils-25.3.1" level="project" />
-    <orderEntry type="library" exported="" name="support-fragment-25.3.1" level="project" />
-    <orderEntry type="library" exported="" name="okio-1.3.0" level="project" />
-    <orderEntry type="library" exported="" scope="TEST" name="multidex-instrumentation-1.0.1" level="project" />
-    <orderEntry type="library" exported="" name="stream-1.0.5" level="project" />
-    <orderEntry type="library" exported="" name="jackson-core-2.6.4" level="project" />
-    <orderEntry type="library" exported="" name="jbcrypt-0.3m" level="project" />
-    <orderEntry type="library" exported="" name="jackson-databind-2.6.4" level="project" />
-    <orderEntry type="library" exported="" name="multidex-1.0.1" level="project" />
-    <orderEntry type="library" exported="" name="support-v4-25.3.1" level="project" />
-    <orderEntry type="library" exported="" name="support-media-compat-25.3.1" level="project" />
-    <orderEntry type="library" exported="" scope="TEST" name="hamcrest-core-1.3" level="project" />
-    <orderEntry type="library" exported="" name="commons-codec-1.10" level="project" />
-    <orderEntry type="library" exported="" scope="TEST" name="junit-4.12" level="project" />
-    <orderEntry type="library" exported="" name="recyclerview-v7-25.3.1" level="project" />
-    <orderEntry type="library" exported="" name="support-annotations-25.3.1" level="project" />
-    <orderEntry type="library" exported="" name="appcompat-v7-25.3.1" level="project" />
-    <orderEntry type="library" exported="" name="support-vector-drawable-25.3.1" level="project" />
-    <orderEntry type="library" exported="" name="support-compat-25.3.1" level="project" />
-    <orderEntry type="library" exported="" name="animated-vector-drawable-25.3.1" level="project" />
-    <orderEntry type="library" exported="" name="timber-4.1.0" level="project" />
+    <orderEntry type="library" name="Gradle: com.madgag.spongycastle:core:1.54.0.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:transition-27.1.1" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-v4-27.1.1" level="project" />
+    <orderEntry type="library" name="Gradle: android.arch.lifecycle:common:1.1.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-annotations:27.1.1@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.fasterxml.jackson.core:jackson-core:2.6.4@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:animated-vector-drawable-27.1.1" level="project" />
+    <orderEntry type="library" name="Gradle: commons-codec:commons-codec:1.10@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-compat-27.1.1" level="project" />
+    <orderEntry type="library" name="Gradle: com.squareup.okhttp:okhttp:2.5.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: android.arch.lifecycle:viewmodel-1.1.0" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:recyclerview-v7-27.1.1" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-vector-drawable-27.1.1" level="project" />
+    <orderEntry type="library" name="Gradle: ch.acra:acra-4.9.0" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-media-compat-27.1.1" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:multidex-1.0.3" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-core-ui-27.1.1" level="project" />
+    <orderEntry type="library" name="Gradle: com.madgag.spongycastle:prov:1.54.0.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-core-utils-27.1.1" level="project" />
+    <orderEntry type="library" name="Gradle: com.annimon:stream:1.0.5@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:support-fragment-27.1.1" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.zxing:core:3.2.1@jar" level="project" />
+    <orderEntry type="library" name="Gradle: android.arch.core:runtime-1.1.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: junit:junit:4.12@jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: org.hamcrest:hamcrest-core:1.3@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.fasterxml.jackson.core:jackson-databind:2.6.4@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:design-27.1.1" level="project" />
+    <orderEntry type="library" name="Gradle: com.android.support:appcompat-v7-27.1.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: com.android.support:multidex-instrumentation-1.0.2" level="project" />
+    <orderEntry type="library" name="Gradle: android.arch.lifecycle:livedata-core-1.1.0" level="project" />
+    <orderEntry type="library" name="Gradle: org.mindrot:jbcrypt:0.3m@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.squareup.okio:okio:1.6.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.fasterxml.jackson.core:jackson-annotations:2.6.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: android.arch.core:common:1.1.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.jakewharton.timber:timber-4.1.0" level="project" />
+    <orderEntry type="library" name="Gradle: android.arch.lifecycle:runtime-1.1.0" level="project" />
+    <orderEntry type="library" name="Gradle: nl.qbusict:cupboard:2.1.4@jar" level="project" />
   </component>
 </module>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,8 @@
 apply plugin: 'com.android.application'
-apply plugin: 'me.tatarka.retrolambda'
 
 buildscript {
     repositories {
         mavenCentral()
-    }
-    dependencies {
-        classpath 'me.tatarka:gradle-retrolambda:3.2.5'
     }
 }
 
@@ -23,8 +19,10 @@ android {
              storePassword keystoreProperties['storePassword']
          }
      }  */
-    compileSdkVersion 25
-    buildToolsVersion '25.0.0'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
+
+    flavorDimensions "default"
     tasks.whenTaskAdded { task ->
         //println("J343 ***************** ---------- *******************"+task.name);
         switch (task.name) {
@@ -50,7 +48,7 @@ android {
     def String versionNameStr = getVersionName()
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 25
+        targetSdkVersion 27
         versionCode 104
         versionName versionNameStr
         multiDexEnabled true
@@ -127,15 +125,6 @@ android {
 String java8 = getJavaVersion(8)
 String java7 = getJavaVersion(7)
 
-retrolambda {
-    javaVersion JavaVersion.VERSION_1_7
-
-    println("J343 ***************** ---------- *******************")
-    println("J343 JAVA8_HOME: " + java8)
-    println("J343 JAVA7_HOME: " + java7)
-    println("J343 ***************** ---------- *******************")
-}
-
 String getJavaVersion(Integer v) {
     def sout = new StringBuffer()
     def proc = "/usr/libexec/java_home -v 1.$v".execute()
@@ -147,18 +136,18 @@ String getJavaVersion(Integer v) {
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:multidex:1.0.1'
+    compile 'com.android.support:multidex:1.0.3'
     compile 'com.annimon:stream:1.0.5'
     compile 'com.jakewharton.timber:timber:4.1.0'
-    compile 'com.madgag.spongycastle:prov:1.51.0.0'
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.android.support:design:25.3.1'
-    compile 'com.android.support:support-v4:25.3.1'
+    compile 'com.madgag.spongycastle:prov:1.54.0.0'
+    compile 'com.android.support:appcompat-v7:27.1.1'
+    compile 'com.android.support:design:27.1.1'
+    compile 'com.android.support:support-v4:27.1.1'
     compile 'com.google.zxing:core:3.2.1'
     compile 'nl.qbusict:cupboard:2.1.4'
-    compile 'com.squareup.okhttp:okhttp:2.3.0'
+    compile 'com.squareup.okhttp:okhttp:2.5.0'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.6.4'
-    compile 'com.madgag.spongycastle:core:1.51.0.0'
+    compile 'com.madgag.spongycastle:core:1.54.0.0'
     compile 'commons-codec:commons-codec:1.10'
     compile 'ch.acra:acra:4.9.0'
     compile 'org.mindrot:jbcrypt:0.3m'
@@ -229,12 +218,8 @@ task build_testnetApp <<{
 def setApkName() {
     android.applicationVariants.all { variant ->
         if (variant.buildType.name == "release") {
-            variant.outputs.each { output ->
-                output.outputFile = new File(
-                        output.outputFile.parent,
-                        output.outputFile.name
-                                .replace("app-", "NEM")
-                                .replace(".apk", "_v${android.defaultConfig.versionName}.apk"))
+            variant.outputs.all { output ->
+                outputFileName = "NEM_v${android.defaultConfig.versionName}.apk"
             }
         }
     }

--- a/app/src/main/java/org/nem/nac/ui/activities/QrTabsActivity.java
+++ b/app/src/main/java/org/nem/nac/ui/activities/QrTabsActivity.java
@@ -75,7 +75,7 @@ public final class QrTabsActivity extends NacBaseActivity {
 			return;
 		}
 		//
-		_viewPager = (ViewPager)findViewById(R.id.viewpager);
+		_viewPager = findViewById(R.id.viewpager);
 		//
 		_adapter = new ViewPagerAdapter(getSupportFragmentManager());
 		_adapter.addFragment(MyInfoFragment.create(account.get()), getString(R.string.title_fragment_my_info));

--- a/build.gradle
+++ b/build.gradle
@@ -4,9 +4,10 @@ buildscript {
     repositories {
         mavenCentral()
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.2'
+        classpath 'com.android.tools.build:gradle:3.1.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -17,5 +18,6 @@ allprojects {
     repositories {
         mavenCentral()
         jcenter()
+        google()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
-#Sat Jun 17 00:55:52 MYT 2017
+#Mon Apr 23 19:23:41 CEST 2018
 //distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
This PR is just a rewrite of PR #292, allowing the project to be build in Android Studio 3+.

Change in QrTabsActivity.java was needed because of changes in API 25.

It was needed to add Google() repository in order to both find Gradle 3 plugin and Support Libraries. RetroLamba is not needed now. Some libraries have also been updated to newer versions. Qr library could also be updated to one of the latest versions which are API 15 compatible, but that is better to be done in another bug so it could be tested in a better way.

The naming function was needed to be simplified also because of changes in Gradle build. It keeps naming the release apk as NEM_v1.0.59.apk for release builds.

It has been tested for both debug and release build bariants in Android Studio 3.1.1 for mainnet.

I am rejecting bounty prize for this PR. It must be sent to 292 PR author/s, as I have only rewrote it.