### PR TITLE
Update gradle-4.4 

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,8 @@
 #Sat Jun 17 00:55:52 MYT 2017
-//distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+//distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+android.enableD8=false
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
Hi, 

address Bounty: NDI55N-OEHLZS-PNIZEU-L2XU7S-3477UZ-PBNZ5Q-5BPQ

update Grable-4.4 
utils:
    Automatic project synchronization
    Runtime classpath separation
    Java 9 compatibility for Buildship plugins
++++++++++++++++++++++++++++++++++
desible support  new compiler; 
enableD8 = False; 
and #305 too

font: https://newsletter.gradle.com/2017/12